### PR TITLE
Add more lines

### DIFF
--- a/interactive/app.js
+++ b/interactive/app.js
@@ -15,18 +15,19 @@ const getRandomId = () => {
 }
 
 const defaultSettings = {
-	base: 'UNRATE',
-	relative: 'UNRATE',
-	recession: 'USREC',
-	k: 3,
-	m: 3,
-	time_period: 13,
-	seasonal: false,
-	alpha_threshold: 0.5
+	base: 'UNRATE', // Base dataset
+	relative: 'UNRATE', // Relative dataset
+	recession: 'USREC', // Recession dataset. Shared across all lines
+	k: 3, // Base (Minued)
+	m: 3, // Relative (Subtrahend)
+	time_period: 13, // Time period
+	seasonal: false, // Seasonal adjustment
+	alpha_threshold: 0.5 // Alpha threshold. Shared across all lines
 }
 
 const data_base_url = '../data-source'
 
+// Statistics constants
 const accuracy_time_range = 200
 const committee_time_range = 250
 const committee_starts = [

--- a/interactive/index.html
+++ b/interactive/index.html
@@ -179,7 +179,7 @@
     </div>
     <hr />
     <div class="row">
-      <div class="col-sm-12">
+      <div class="col-sm-12 col-md-6">
         <h3>Modified Sahm Rule</h3>
         <p class="text-muted text-small">
           The modified Sahm Recession Indicator. <br />
@@ -188,6 +188,22 @@
           Interactive Tool Version 1.1 Beta. <br /> 
           Last updated: 13 February 2025.
         </p>
+      </div>
+      <div class="col-sm-12 col-md-6">
+        <div class="control-buttons">
+          <button type="button" class="btn btn-light btn-sm" id="remove-line-button">
+            <i class="fa fa-minus-circle"></i>
+            Remove line
+          </button>
+          <button type="button" class="btn btn-light btn-sm" id="add-line-button">
+            <i class="fa fa-plus-circle"></i>
+            Add line
+          </button>
+          <button type="button" class="btn btn-light btn-sm" id="download-data-button">
+            <i class="fa fa-download"></i>
+            Download data
+          </button>
+        </div>
       </div>
     </div>
 

--- a/interactive/sahm_rule.js
+++ b/interactive/sahm_rule.js
@@ -32,10 +32,9 @@ export function compute_sahm_rule(
 			// recession: recession_data[i]?.value ?? 0, TODO: Add recession data
 			// base_k_mo_avg: base_k_mo_avg[i],
 			// relative_m_mo_min_12mo: relative_m_mo_min_12mo[i],
-			sahm: sahm,
+			// sahm: sahm,
 			// sahm_binary: sahm >= alpha_threshold ? 1 : 0,
-			value: sahm,
-			category: 'Modified Sahm Rule'
+			value: sahm
 		})
 	}
 
@@ -66,7 +65,7 @@ export function getSahmStarts(data, alpha_threshold = 0.5) {
 	let lastStart = null
 	for (let i = 0; i < data.length; i++) {
 		const datum = data[i]
-		const sahm_binary = datum.sahm >= alpha_threshold ? 1 : 0
+		const sahm_binary = datum.value >= alpha_threshold ? 1 : 0
 		if (lastStart && sahm_binary === 0) {
 			lastStart = null
 		} else if (!lastStart && sahm_binary === 1) {

--- a/interactive/sahm_rule.js
+++ b/interactive/sahm_rule.js
@@ -29,11 +29,6 @@ export function compute_sahm_rule(
 		const sahm = base_k_mo_avg[i] - relative_m_mo_min_time_period[i]
 		computed_data.push({
 			date: base_data[i].date,
-			// recession: recession_data[i]?.value ?? 0, TODO: Add recession data
-			// base_k_mo_avg: base_k_mo_avg[i],
-			// relative_m_mo_min_12mo: relative_m_mo_min_12mo[i],
-			// sahm: sahm,
-			// sahm_binary: sahm >= alpha_threshold ? 1 : 0,
 			value: sahm
 		})
 	}

--- a/interactive/sahm_rule.js
+++ b/interactive/sahm_rule.js
@@ -2,12 +2,10 @@
 export function compute_sahm_rule(
 	base_data,
 	relative_data,
-	recession_data,
 	k = 3,
 	m = 3,
 	time_period = 13,
-	seasonal = false,
-	alpha_threshold = 0.5
+	seasonal = false
 ) {
 	const n = base_data.length
 	const base = new Float64Array(n).fill(0)
@@ -21,18 +19,21 @@ export function compute_sahm_rule(
 
 	const base_k_mo_avg = movingAverage(base, k)
 	const relative_m_mo_avg = movingAverage(relative, m)
-	const relative_m_mo_min_time_period = rollingMin(relative_m_mo_avg, time_period)
+	const relative_m_mo_min_time_period = rollingMin(
+		relative_m_mo_avg,
+		time_period
+	)
 
 	const computed_data = []
 	for (let i = 0; i < n; i++) {
 		const sahm = base_k_mo_avg[i] - relative_m_mo_min_time_period[i]
 		computed_data.push({
 			date: base_data[i].date,
-			recession: recession_data[i]?.value ?? 0,
+			// recession: recession_data[i]?.value ?? 0, TODO: Add recession data
 			// base_k_mo_avg: base_k_mo_avg[i],
 			// relative_m_mo_min_12mo: relative_m_mo_min_12mo[i],
 			sahm: sahm,
-			sahm_binary: sahm >= alpha_threshold ? 1 : 0,
+			// sahm_binary: sahm >= alpha_threshold ? 1 : 0,
 			value: sahm,
 			category: 'Modified Sahm Rule'
 		})
@@ -60,14 +61,15 @@ export function getRecessionPeriods(recession_data) {
 	return resp
 }
 
-export function getSahmStarts(data) {
+export function getSahmStarts(data, alpha_threshold = 0.5) {
 	const resp = []
 	let lastStart = null
 	for (let i = 0; i < data.length; i++) {
 		const datum = data[i]
-		if (lastStart && datum.sahm_binary === 0) {
+		const sahm_binary = datum.sahm >= alpha_threshold ? 1 : 0
+		if (lastStart && sahm_binary === 0) {
 			lastStart = null
-		} else if (!lastStart && datum.sahm_binary === 1) {
+		} else if (!lastStart && sahm_binary === 1) {
 			lastStart = datum.date
 			resp.push(lastStart)
 		}

--- a/interactive/tool.css
+++ b/interactive/tool.css
@@ -11,6 +11,10 @@ body {
   margin: 0;
 }
 
+.btn:focus {
+  outline: none !important;
+}
+
 .row.slim > div {
   padding-left: 7.5px;
   padding-right: 7.5px;
@@ -122,4 +126,12 @@ input[type="range"] {
 .checkbox-container {
   padding-top: 6px;
   text-align: center;
+}
+
+.control-buttons {
+  text-align: right;
+}
+
+.series-path.active {
+  stroke: rgb(173, 74, 12);
 }

--- a/interactive/tool.css
+++ b/interactive/tool.css
@@ -132,6 +132,22 @@ input[type="range"] {
   text-align: right;
 }
 
-.series-path.active {
-  stroke: rgb(173, 74, 12);
+.legend {
+  margin-bottom: 1rem;
+}
+
+.swatch {
+  transition: background-color 0.3s ease;
+  padding: 0.5rem;
+  border-radius: 0.25rem 0.25rem 0 0;
+  border-bottom: 1px solid transparent;
+}
+
+.swatch:hover {
+  background-color: #eee;
+  cursor: pointer;
+}
+
+.swatch[data-active="true"] {
+  border-bottom: 1px solid rgb(254, 187, 2);
 }

--- a/vis/v-recession-indicator-chart.js
+++ b/vis/v-recession-indicator-chart.js
@@ -8,7 +8,8 @@ export default function vRecessionIndicatorChart({
   threshold = 0.5, 
   hideHeader, 
   hideFooter, 
-  hideLegend 
+  hideLegend,
+  onLegendClick
 }) {
   /**
    * Constants
@@ -31,7 +32,7 @@ export default function vRecessionIndicatorChart({
 
   // Data
   // const { dates, series, periods } = processData(data, factor);
-  const { dates, series, periods } = data;
+  let { dates, series, periods } = data;
 
   // Scales
   const xScale = d3.scaleUtc().domain(d3.extent(dates));
@@ -149,6 +150,14 @@ export default function vRecessionIndicatorChart({
     vSwatches({
       container: legend,
       scale: colorScale,
+      active: d => series.find(s => s.key === d).active,
+      label: d => series.find(s => s.key === d).label,
+      onClick: (e, d) => {
+        if (!onLegendClick) return;
+        series = series.map(s => ({ ...s, active: s.key === d }));
+        renderLegend();
+        onLegendClick(d);
+      }
     });
   }
 
@@ -427,6 +436,7 @@ export default function vRecessionIndicatorChart({
     return { dates, series, periods };
   }
 
+  // utcFormat converts date to UTC for
   function tooltipContent() {
     return /*html*/ `
     <div>
@@ -448,7 +458,7 @@ export default function vRecessionIndicatorChart({
                   <div class="swatch__swatch" style="background-color: ${colorScale(
                     d.key
                   )}"></div>
-                  <div class="swatch__label">${d.key}</div>
+                  <div class="swatch__label">${d.label}</div>
                 </div>
               </td>
               <td>
@@ -477,5 +487,12 @@ export default function vRecessionIndicatorChart({
       threshold = newThreshold;
       renderThreshold();
     },
+    getData: () => {
+      return {
+        dates,
+        series,
+        periods
+      }
+    }
   }
 }

--- a/vis/v-recession-indicator-chart.js
+++ b/vis/v-recession-indicator-chart.js
@@ -30,7 +30,8 @@ export default function vRecessionIndicatorChart({
   let width, iFocus, animated;
 
   // Data
-  const { dates, series, periods } = processData(data, factor);
+  // const { dates, series, periods } = processData(data, factor);
+  const { dates, series, periods } = data;
 
   // Scales
   const xScale = d3.scaleUtc().domain(d3.extent(dates));
@@ -89,6 +90,7 @@ export default function vRecessionIndicatorChart({
     .on("pointermove", moved)
     .on("pointerleave", left)
     .on("touchstart", (event) => event.preventDefault());
+
   const periodsG = svg.append("g").attr("class", "periods-g");
   const xAxisG = svg.append("g").attr("class", "axis-g");
   const yAxisG = svg.append("g").attr("class", "axis-g");
@@ -97,6 +99,7 @@ export default function vRecessionIndicatorChart({
     .append("g")
     .attr("class", "focus-g")
     .attr("display", "none");
+
   const thresholdG = svg.append("g").attr("class", "threshold-g");
   const footer = figure.append("div").attr("class", "footer");
 
@@ -113,20 +116,20 @@ export default function vRecessionIndicatorChart({
   }
 
   new ResizeObserver(resize).observe(body.node());
-  const observer = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          animate();
-          observer.disconnect();
-        }
-      });
-    },
-    {
-      threshold: 0.5,
-    }
-  );
-  observer.observe(svg.node());
+  // const observer = new IntersectionObserver(
+  //   (entries) => {
+  //     entries.forEach((entry) => {
+  //       if (entry.isIntersecting) {
+  //         animate();
+  //         observer.disconnect();
+  //       }
+  //     });
+  //   },
+  //   {
+  //     threshold: 0.5,
+  //   }
+  // );
+  // observer.observe(svg.node());
 
   function renderHeader() {
     const titleByFactor = {
@@ -239,6 +242,7 @@ export default function vRecessionIndicatorChart({
     seriesG
       .attr("fill", "none")
       .selectChildren(".series-path")
+      .classed("active", (d) => d.active)
       .data(series, (d) => d.key)
       .join((enter) =>
         enter
@@ -466,5 +470,12 @@ export default function vRecessionIndicatorChart({
       </table>
     </div>
     `;
+  }
+
+  return {
+    updateThreshold: (newThreshold) => {
+      threshold = newThreshold;
+      renderThreshold();
+    },
   }
 }

--- a/vis/v-swatches.js
+++ b/vis/v-swatches.js
@@ -1,24 +1,37 @@
-export default function vSwatches({ container, scale }) {
-  container
-    .append("div")
-    .attr("class", "swatches")
-    .selectChildren()
-    .data(scale.domain())
-    .join((enter) =>
-      enter
-        .append("div")
-        .attr("class", "swatch")
-        .call((div) =>
-          div
-            .append("div")
-            .attr("class", "swatch__swatch")
-            .style("background-color", (d) => scale(d))
-        )
-        .call((div) =>
-          div
-            .append("div")
-            .attr("class", "swatch__label")
-            .text((d) => d)
-        )
-    );
+export default function vSwatches({
+	container,
+	scale,
+	label,
+	onClick,
+	active
+}) {
+	const swatches = container
+		.selectAll('div.swatches')
+		.data(['swatches'])
+		.join('div')
+		.attr('class', 'swatches')
+
+	swatches
+		.selectAll('div.swatch')
+		.data(scale.domain())
+		.join('div')
+		.attr('class', 'swatch')
+		.attr('data-active', d => active(d))
+		.on('click', (e, d) => onClick(e, d))
+		.call(div =>
+			div
+				.selectAll('div.swatch__swatch')
+				.data(d => [d])
+				.join('div')
+				.attr('class', 'swatch__swatch')
+				.style('background-color', d => scale(d))
+		)
+		.call(div =>
+			div
+				.selectAll('div.swatch__label')
+				.data(d => [d])
+				.join('div')
+				.attr('class', 'swatch__label')
+				.text(d => label(d))
+		)
 }


### PR DESCRIPTION
Huge changes!

# Add Multi-Line Support to Sahm Rule Dashboard

## Changes
- Refactored dashboard to support multiple data series visualization
- Added UI controls to add/remove lines and switch between them
- Implemented data caching to improve performance
- Added CSV export functionality for chart data
- Enhanced visualization with active line highlighting

## Technical Details
- Each line has unique ID and independent configuration
- Shared recession data across all lines
- Data alignment ensures consistent date ranges
- Added comments for better code maintainability
