### PR TITLE
feature/preceding-natural-rate

### DIFF
--- a/interactive/index.html
+++ b/interactive/index.html
@@ -285,7 +285,6 @@
 
 
 
-
   <script type="text/javascript" src="../js/jquery-1.11.0.min.js"></script>
   <script type="text/javascript" src="../js/bootstrap.min.js"></script>
   <script type="module" type="text/javascript">


### PR DESCRIPTION
### What's New:
1. **Preceding**: This new feature adds a lag, letting users skip the current month in the relative unemployment calculation.
2. **Natural Rate Slider**: Users can now set a floor for unemployment before the Sahm Rule calculation.  
   - Default is 0 (off), but you can raise it up to 7 in 0.1 increments.
   - If unemployment is 4.0 but you set the natural rate to 4.3, the function will reset it to 4.3.

### UI/UX Improvements:
- Rearranged layout slightly for clarity
- Moved all subtitle info under the title
- Updated icons:
  - Add: `fa-light fa-circle-plus`
  - Delete: `fa-light fa-circle-minus`
  - Download: `fa-light fa-arrow-down-to-line`